### PR TITLE
feat: cálculo automático de días de retraso en devoluciones

### DIFF
--- a/src/main/java/com/bibliotech/model/Prestamo.java
+++ b/src/main/java/com/bibliotech/model/Prestamo.java
@@ -7,6 +7,7 @@ public class Prestamo {
     private int socioId;
     private String isbn;
     private LocalDate fecha;
+    private LocalDate fechaDevolucion;
     private boolean devuelto;
 
     public Prestamo(int socioId, String isbn) {
@@ -14,10 +15,12 @@ public class Prestamo {
         this.isbn = isbn;
         this.fecha = LocalDate.now();
         this.devuelto = false;
+        this.fechaDevolucion = null;
     }
 
     public void devolver() {
         this.devuelto = true;
+        this.fechaDevolucion = LocalDate.now();
     }
 
     public boolean isDevuelto() {
@@ -30,5 +33,13 @@ public class Prestamo {
 
     public String getIsbn() {
         return isbn;
+    }
+
+    public LocalDate getFecha() {
+        return fecha;
+    }
+
+    public LocalDate getFechaDevolucion() {
+        return fechaDevolucion;
     }
 }

--- a/src/main/java/com/bibliotech/service/PrestamoService.java
+++ b/src/main/java/com/bibliotech/service/PrestamoService.java
@@ -3,6 +3,8 @@ package com.bibliotech.service;
 import com.bibliotech.model.*;
 import com.bibliotech.repository.Repository;
 
+import java.time.temporal.ChronoUnit;
+
 public class PrestamoService {
 
     private final Repository<Libro, String> libroRepo;
@@ -24,10 +26,9 @@ public class PrestamoService {
         Socio socio = socioRepo.buscarPorId(socioId)
                 .orElseThrow(() -> new RuntimeException("Socio no existe"));
 
-        Libro libro = libroRepo.buscarPorId(isbn)
+        libroRepo.buscarPorId(isbn)
                 .orElseThrow(() -> new RuntimeException("Libro no existe"));
 
-        // verificar disponibilidad (solo préstamos activos)
         boolean prestado = prestamoRepo.buscarTodos().stream()
                 .anyMatch(p -> p.getIsbn().equals(isbn) && !p.isDevuelto());
 
@@ -35,7 +36,6 @@ public class PrestamoService {
             throw new RuntimeException("Libro no disponible");
         }
 
-        // validar límite del socio
         long cantidad = prestamoRepo.buscarTodos().stream()
                 .filter(p -> p.getSocioId() == socioId && !p.isDevuelto())
                 .count();
@@ -59,6 +59,20 @@ public class PrestamoService {
 
         prestamo.devolver();
 
-        prestamoRepo.guardar(prestamo); // o update si tu repo lo soporta
+        prestamoRepo.guardar(prestamo);
+    }
+
+    public long calcularDiasRetraso(Prestamo prestamo, int diasPermitidos) {
+
+        if (!prestamo.isDevuelto()) {
+            throw new RuntimeException("El libro aún no fue devuelto");
+        }
+
+        long dias = ChronoUnit.DAYS.between(
+                prestamo.getFecha(),
+                prestamo.getFechaDevolucion()
+        );
+
+        return Math.max(0, dias - diasPermitidos);
     }
 }


### PR DESCRIPTION
Se implementa el cálculo de días de retraso en la devolución de libros.

Cambios realizados:
- Se agrega fecha de devolución en Prestamo
- Se registra la fecha al momento de devolver un libro
- Se implementa cálculo de diferencia entre fecha de préstamo y devolución
- Se determina retraso considerando días permitidos

Esto permite extender el sistema de préstamos con control de penalizaciones futuras.